### PR TITLE
Fix typographical error in Nkrumah timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
           </li>
           <li class="flex flex-col sm:flex-row items-start py-5 border-b border-stone-300 dark:border-neutral-700 last:border-b-0">
             <span class="bg-yellow-500 text-white dark:bg-yellow-600 dark:text-neutral-900 font-bold rounded-full px-3 py-1 text-xs sm:text-sm mr-0 mb-2 sm:mr-4 sm:mb-0 shrink-0 w-auto inline-block text-center min-w-[140px] sm:min-w-[150px]">1972 (April 27th)</span>
-            <span class="font-normal leading-relaxed">Died of natural causes in a Romania</span>
+            <span class="font-normal leading-relaxed">Died of natural causes in Romania</span>
           </li>
           <li class="flex flex-col sm:flex-row items-start py-5 border-b-0"> {/* Note: last:border-b-0 is implicitly handled here for the last item, but added it explicitly in classes above */}
             <span class="bg-yellow-500 text-white dark:bg-yellow-600 dark:text-neutral-900 font-bold rounded-full px-3 py-1 text-xs sm:text-sm mr-0 mb-2 sm:mr-4 sm:mb-0 shrink-0 w-auto inline-block text-center min-w-[110px] sm:min-w-[120px]">1972 (7 July)</span>


### PR DESCRIPTION
## Summary
- corrected a typo in the 1972 timeline entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fd4bf4c648329927a94025324a2a0